### PR TITLE
fix: remove 'copy' from dependencies as it is a built-in module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,7 @@ dependencies = [
     'networkx',
     'igraph',
     'pyvis',
-    'zstandard',
-    'copy'
+    'zstandard'
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -2784,7 +2784,7 @@ wheels = [
 
 [[package]]
 name = "tct"
-version = "0.1.6"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This PR removes the copy module from the dependencies list in pyproject.toml. The copy module is part of the Python Standard Library and should not be listed as an external dependency. This was causing uv sync to fail.

Closes #31 